### PR TITLE
Errore con table-per-class

### DIFF
--- a/src/model/Utente.java
+++ b/src/model/Utente.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 public abstract class Utente {
 	
 	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
+	@GeneratedValue(strategy = GenerationType.TABLE)
 	private int id;
 	
 	@Column


### PR DESCRIPTION
Avevo come errore 'cannot use identity column key generation with union-subclass mapping. **Sostituendo GenerationType.AUTO con .TABLE** nella classe Utente mi funziona tutto, parrebbe.

[Stackoverflow Rulez](https://stackoverflow.com/questions/916169/cannot-use-identity-column-key-generation-with-union-subclass-table-per-clas)